### PR TITLE
feat: integración del modelo real en el endpoint /predict

### DIFF
--- a/fast_api/model_loader.py
+++ b/fast_api/model_loader.py
@@ -1,0 +1,18 @@
+import os
+import joblib
+
+# Ruta a la carpeta final_model
+BASE_PATH = os.path.dirname(os.path.dirname(__file__))
+MODEL_DIR = os.path.join(BASE_PATH, "final_model")
+
+# Cargar vectorizador y modelo
+VECTORIZER_PATH = os.path.join(MODEL_DIR, "vectorizer_toxicidad_final.pkl")
+MODEL_PATH = os.path.join(MODEL_DIR, "modelo_toxicidad_xgboost_final.pkl")
+
+vectorizer = joblib.load(VECTORIZER_PATH)
+model = joblib.load(MODEL_PATH)
+
+def predict_label(text: str) -> bool:
+    X = vectorizer.transform([text])
+    prediction = model.predict(X)
+    return bool(prediction[0])

--- a/fast_api/routers/predictions.py
+++ b/fast_api/routers/predictions.py
@@ -4,6 +4,7 @@ from typing import List
 from ..schemas import PredictionRequest, PredictionResponse, PredictionRecord
 from ..config import MODEL_VERSION
 from ..supabase_client import supabase
+from ..model_loader import predict_label
 
 router = APIRouter()
 
@@ -11,7 +12,7 @@ router = APIRouter()
 @router.post("/predict", response_model=PredictionResponse)
 def predict(request: PredictionRequest):
     text = request.text
-    is_toxic = "hate" in text.lower() or "stupid" in text.lower()
+    is_toxic = predict_label(text)
 
     if supabase:
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -197,5 +197,6 @@ websockets==15.0.1
 widgetsnbextension==4.0.14
 wordcloud==1.9.4
 wrapt==1.17.2
+xgboost==3.0.2
 xxhash==3.5.0
 yarl==1.20.1


### PR DESCRIPTION
Esta PR implementa la lógica de predicción real en el backend usando un modelo XGBoost y su vectorizador, ambos cargados desde final_model/.
Se elimina la lógica simulada y ahora el endpoint /predict usa el modelo entrenado para clasificar comentarios de forma real.